### PR TITLE
GNOME - Save settings and kill cava on quit

### DIFF
--- a/NickvisionCavalier.GNOME/NickvisionCavalier.GNOME.csproj
+++ b/NickvisionCavalier.GNOME/NickvisionCavalier.GNOME.csproj
@@ -20,7 +20,7 @@
     <Exec Command="echo Compiling extra resources..." />
     <Exec Command="blueprint-compiler batch-compile ./Blueprints ./Blueprints ./Blueprints/*.blp" />
     <Exec Command="glib-compile-resources --sourcedir ./Resources ./Resources/org.nickvision.cavalier.gresource.xml --target=$(OutDir)/org.nickvision.cavalier.gresource" />
-    <Exec Command="&#xA;      while read lang_code; do \&#xA;        mkdir -p $(OutDir)/${lang_code}; \&#xA;        msgfmt ../NickvisionCavalier.Shared/Resources/po/${lang_code}.po -o $(OutDir)/${lang_code}/cavalier.mo; \&#xA;      done %3C ../NickvisionCavalier.Shared/Resources/po/LINGUAS" />
+    <Exec Command="while read lang_code; do \&#xA;    mkdir -p $(OutDir)/${lang_code};\&#xA;    msgfmt ../NickvisionCavalier.Shared/Resources/po/${lang_code}.po -o $(OutDir)/${lang_code}/cavalier.mo;\&#xA;done %3C ../NickvisionCavalier.Shared/Resources/po/LINGUAS" />
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
@@ -29,7 +29,7 @@
 
   <Target Name="PostPublish" AfterTargets="Publish">
     <Exec Command="cp $(OutDir)/org.nickvision.cavalier.gresource $(PublishDir)/org.nickvision.cavalier.gresource" />
-    <Exec Command="&#xA;      while read lang_code; do \&#xA;        cp -r $(OutDir)/${lang_code} $(PublishDir)/; \&#xA;      done %3C ../NickvisionCavalier.Shared/Resources/po/LINGUAS" />
+    <Exec Command="while read lang_code; do \&#xA;    cp -r $(OutDir)/${lang_code} $(PublishDir)/; \&#xA;done %3C ../NickvisionCavalier.Shared/Resources/po/LINGUAS" />
   </Target>
 
   <Target Name="EmbedUIFiles" BeforeTargets="BeforeResGen">


### PR DESCRIPTION
`application.Quit` doesn't call `window.OnClose`, so we need to save settings and kill cava here too.