### PR TITLE
Cairo renderer

### DIFF
--- a/NickvisionCavalier.GNOME/Blueprints/drawing_view.blp
+++ b/NickvisionCavalier.GNOME/Blueprints/drawing_view.blp
@@ -23,4 +23,12 @@ Gtk.Stack _root {
       auto-render: false;
     };
   }
+
+  Gtk.StackPage _cairoPage {
+    name: "cairo";
+    child: Gtk.DrawingArea _cairoArea {
+      hexpand: true;
+      vexpand: true;
+    };
+  }
 }

--- a/NickvisionCavalier.GNOME/Program.cs
+++ b/NickvisionCavalier.GNOME/Program.cs
@@ -34,13 +34,7 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
-            @"* Cavalier can now be controlled from command line. Run the app with --help option to see full list of available options
-              * Reverse mirror option is now available with full mirror
-              * It's now possible to set frames per second to 144 or to a custom value
-              * Added anti-aliasing, so rounded items now look less pixelated
-              * Added ability to set background image
-              * New drawing mode - Splitter
-              * Bars limit was increased to 100
+            @"* Added Cairo backend that can be used in case of problems with OpenGL. To activate, run the program with environment variable CAVALIER_RENDERER=cairo
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.cavalier.gresource"))

--- a/NickvisionCavalier.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionCavalier.Shared/Controllers/MainWindowController.cs
@@ -60,7 +60,7 @@ public class MainWindowController
     {
         Aura = new Aura("org.nickvision.cavalier", "Nickvision Cavalier", _("Cavalier"), _("Visualize audio with CAVA"));
         Aura.Active.SetConfig<Configuration>("config");
-        AppInfo.Version = "2023.8.0";
+        AppInfo.Version = "2023.8.1-next";
         AppInfo.SourceRepo = new Uri("https://github.com/NickvisionApps/Cavalier");
         AppInfo.IssueTracker = new Uri("https://github.com/NickvisionApps/Cavalier/issues/new");
         AppInfo.SupportUrl = new Uri("https://github.com/NickvisionApps/Cavalier/discussions");

--- a/NickvisionCavalier.Shared/org.nickvision.cavalier.metainfo.xml.in
+++ b/NickvisionCavalier.Shared/org.nickvision.cavalier.metainfo.xml.in
@@ -35,17 +35,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release type="stable" date="2023-07-04" version="2023.8.0">
+    <release type="stable" date="2023-07-04" version="2023.8.1-next">
       <description translatable="no">
         <p>New Cavalier!</p>
         <ul>
-          <li>Cavalier can now be controlled from command line. Run the app with --help option to see full list of available options</li>
-          <li>Reverse mirror option is now available with full mirror</li>
-          <li>It's now possible to set frames per second to 144 or to a custom value</li>
-          <li>Added anti-aliasing, so rounded items now look less pixelated</li>
-          <li>Added ability to set background image</li>
-          <li>New drawing mode - Splitter</li>
-          <li>Bars limit was increased to 100</li>
+          <li>Added Cairo backend that can be used in case of problems with OpenGL. To activate, run the program with environment variable CAVALIER_RENDERER=cairo</li>
           <li>Updated translations (Thanks everyone on Weblate!)</li>
         </ul>
       </description>


### PR DESCRIPTION
Closes #70 

This can be used in case of problems with OpenGL renderer.
To enable, environment variable should be set: `CAVALIER_RENDERER=cairo`

How it works (in short): instead of using GLArea, we use DrawingArea to draw with cairo. Cairo image surface is created, and then Skia surface is created using pointer to pixel data of the cairo surface. Skia draws, then cairo surface is rendered to drawing area.

Unlike in Gtk# (I looked at [SkiaSharp.Views.Gtk3](https://github.com/mono/SkiaSharp/blob/main/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SKDrawingArea.cs) code to understand how implement the same with gircore) there are no Destroy or Dispose methods in Cairo.Surface in gircore, but during my tests I didn't notice any memory leaks.