### PR TITLE
Circle variants of drawing modes

### DIFF
--- a/NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp
@@ -16,6 +16,22 @@ Adw.PreferencesWindow _root {
     Adw.PreferencesGroup {
       title: _("Drawing mode");
 
+      [header-suffix]
+      Gtk.Box {
+        halign: center;
+
+        Gtk.ToggleButton _boxButton {
+          label: _("Box");
+        }
+
+        Gtk.ToggleButton {
+          label: _("Circle");
+          active: bind _boxButton.active bidirectional inverted;
+        }
+
+        styles ["linked"]
+      }
+
       Adw.ActionRow {
         title: _("Wave");
         activatable-widget: _waveCheckButton;
@@ -67,10 +83,29 @@ Adw.PreferencesWindow _root {
       Adw.ActionRow {
         title: _("Splitter");
         activatable-widget: _splitterCheckButton;
+        sensitive: bind _boxButton.active;
 
         [prefix]
         Gtk.CheckButton _splitterCheckButton {
           group: _waveCheckButton;
+        }
+      }
+    }
+
+    Adw.PreferencesGroup {
+      Adw.ActionRow {
+        title: _("Radius");
+        visible: bind _boxButton.active inverted;
+
+        [suffix]
+        Gtk.Scale _radiusScale {
+          width-request: 150;
+          draw-value: false;
+          adjustment: Gtk.Adjustment {
+            lower: 0.2;
+            upper: 0.8;
+            step-increment: 0.05;
+          };
         }
       }
     }
@@ -92,6 +127,14 @@ Adw.PreferencesWindow _root {
     }
 
     Adw.PreferencesGroup {
+      Adw.ComboRow _directionRow {
+        title: _("Drawing direction");
+        model: Gtk.StringList {
+          strings [_("Top to bottom"), _("Bottom to top"), _("Left to right"), _("Right to left") ]
+        };
+        sensitive: bind _boxButton.active;
+      }
+
       Adw.ActionRow {
         title: _("Drawing area margin");
         subtitle: _("Size of gaps around drawing area (in pixels).");
@@ -108,13 +151,6 @@ Adw.PreferencesWindow _root {
             step-increment: 1;
           };
         }
-      }
-
-      Adw.ComboRow _directionRow {
-        title: _("Drawing direction");
-        model: Gtk.StringList {
-          strings [_("Top to bottom"), _("Bottom to top"), _("Left to right"), _("Right to left") ]
-        };
       }
 
       Adw.ActionRow _offsetRow {

--- a/NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp
+++ b/NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp
@@ -18,6 +18,11 @@ Gtk.ShortcutsWindow _shortcuts {
       }
 
       Gtk.ShortcutsShortcut {
+        title: _("Change radius in Circle modes");
+        accelerator: "U <Shift>U";
+      }
+
+      Gtk.ShortcutsShortcut {
         title: _("Change Mirror Mode");
         accelerator: "M <Shift>M";
       }

--- a/NickvisionCavalier.GNOME/Program.cs
+++ b/NickvisionCavalier.GNOME/Program.cs
@@ -35,6 +35,9 @@ public partial class Program
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
             @"* Added Cairo backend that can be used in case of problems with OpenGL. To activate, run the program with environment variable CAVALIER_RENDERER=cairo
+              * All drawing modes except Splitter now have Circle variants
+              * Added an easter egg (run the program with --help to find how to activate it)
+              * Fixed an issue where the app wasn't drawing correctly with >100% display scaling
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.cavalier.gresource"))

--- a/NickvisionCavalier.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionCavalier.GNOME/Views/PreferencesDialog.cs
@@ -79,27 +79,39 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         var actNextMode = Gio.SimpleAction.New("next-mode", null);
         actNextMode.OnActivate += (sender, e) =>
         {
-            if (_controller.Mode < DrawingMode.SpineBox)
+            if (_controller.Mode < DrawingMode.SpineCircle)
             {
                 switch (_controller.Mode + 1)
                 {
+                    case DrawingMode.WaveCircle:
+                        _waveCheckButton.SetActive(true);
+                        _boxButton.SetActive(false);
+                        break;
                     case DrawingMode.LevelsBox:
+                    case DrawingMode.LevelsCircle:
                         _levelsCheckButton.SetActive(true);
                         break;
                     case DrawingMode.ParticlesBox:
+                    case DrawingMode.ParticlesCircle:
                         _particlesCheckButton.SetActive(true);
                         break;
                     case DrawingMode.BarsBox:
+                    case DrawingMode.BarsCircle:
                         _barsCheckButton.SetActive(true);
                         break;
                     case DrawingMode.SpineBox:
+                    case DrawingMode.SpineCircle:
                         _spineCheckButton.SetActive(true);
+                        break;
+                    case DrawingMode.SplitterBox:
+                        _splitterCheckButton.SetActive(true);
                         break;
                 }
             }
             else
             {
                 _waveCheckButton.SetActive(true);
+                _boxButton.SetActive(true);
             }
         };
         application.AddAction(actNextMode);
@@ -113,30 +125,69 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
                 switch (_controller.Mode - 1)
                 {
                     case DrawingMode.WaveBox:
+                    case DrawingMode.WaveCircle:
                         _waveCheckButton.SetActive(true);
                         break;
                     case DrawingMode.LevelsBox:
+                    case DrawingMode.LevelsCircle:
                         _levelsCheckButton.SetActive(true);
                         break;
                     case DrawingMode.ParticlesBox:
+                    case DrawingMode.ParticlesCircle:
                         _particlesCheckButton.SetActive(true);
                         break;
                     case DrawingMode.BarsBox:
+                    case DrawingMode.BarsCircle:
                         _barsCheckButton.SetActive(true);
+                        break;
+                    case DrawingMode.SpineBox:
+                    case DrawingMode.SpineCircle:
+                        _spineCheckButton.SetActive(true);
+                        break;
+                    case DrawingMode.SplitterBox:
+                        _boxButton.SetActive(true);
+                        _splitterCheckButton.SetActive(true);
                         break;
                 }
             }
             else
             {
                 _spineCheckButton.SetActive(true);
+                _boxButton.SetActive(false);
             }
         };
         application.AddAction(actPrevMode);
         application.SetAccelsForAction("app.prev-mode", new string[] { "<Shift>d" });
+        //Increase Inner Radius Action
+        var actIncRadius = Gio.SimpleAction.New("inc-radius", null);
+        actIncRadius.OnActivate += (sender, e) =>
+        {
+            if (_radiusScale.GetValue() < 0.8)
+            {
+                _radiusScale.SetValue(_radiusScale.GetValue() + 0.05);
+            }
+        };
+        application.AddAction(actIncRadius);
+        application.SetAccelsForAction("app.inc-radius", new string[] { "u" });
+        //Decreate Inner Radius Action
+        var actDecRadius = Gio.SimpleAction.New("dec-radius", null);
+        actDecRadius.OnActivate += (sender, e) =>
+        {
+            if (_radiusScale.GetValue() > 0.2)
+            {
+                _radiusScale.SetValue(_radiusScale.GetValue() - 0.05);
+            }
+        };
+        application.AddAction(actDecRadius);
+        application.SetAccelsForAction("app.dec-radius", new string[] { "<Shift>u" });
         //Next Mirror Mode Action
         var actNextMirror = Gio.SimpleAction.New("next-mirror", null);
         actNextMirror.OnActivate += (sender, e) =>
         {
+            if (!_mirrorRow.GetSensitive())
+            {
+                return;
+            }
             var maxMirror = _controller.Stereo ? Mirror.SplitChannels : Mirror.Full;
             _mirrorRow.SetSelected(_controller.Mirror < maxMirror ? (uint)_controller.Mirror + 1 : 0);
         };
@@ -146,6 +197,10 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         var actPrevMirror = Gio.SimpleAction.New("prev-mirror", null);
         actPrevMirror.OnActivate += (sender, e) =>
         {
+            if (!_mirrorRow.GetSensitive())
+            {
+                return;
+            }
             var maxMirror = _controller.Stereo ? Mirror.SplitChannels : Mirror.Full;
             _mirrorRow.SetSelected(_controller.Mirror > Mirror.Off ? (uint)_controller.Mirror - 1 : (uint)maxMirror);
         };

--- a/NickvisionCavalier.Shared/Controllers/PreferencesViewController.cs
+++ b/NickvisionCavalier.Shared/Controllers/PreferencesViewController.cs
@@ -161,6 +161,11 @@ public class PreferencesViewController
                 Configuration.Current.ReverseMirror = o.ReverseMirror.Value;
                 updateCavalier = true;
             }
+            if (o.InnerRadius.HasValue)
+            {
+                Configuration.Current.InnerRadius = Math.Max(80, Math.Min(20, o.InnerRadius.Value)) / 100f;
+                updateCavalier = true;
+            }
             if (o.ActiveProfile.HasValue)
             {
                 if (o.ActiveProfile.Value < Configuration.Current.ColorProfiles.Count)
@@ -424,6 +429,16 @@ public class PreferencesViewController
         get => Configuration.Current.Mirror;
 
         set => Configuration.Current.Mirror = value;
+    }
+
+    /// <summary>
+    /// Inner circle radius ratio in circle modes (0.2-0.8)
+    /// </summary>
+    public float InnerRadius
+    {
+        get => Configuration.Current.InnerRadius;
+    
+        set => Configuration.Current.InnerRadius = value;
     }
 
     /// <summary>

--- a/NickvisionCavalier.Shared/Models/CmdOptions.cs
+++ b/NickvisionCavalier.Shared/Models/CmdOptions.cs
@@ -79,7 +79,7 @@ public class CmdOptions {
     /// <summary>
     /// Inner circle radius ratio in circle modes (20-80)
     /// </summary>
-    [Option('u', "inner-radius", Required = false, HelpText = "Inner circle radius in circle modes (20-80)")]
+    [Option('u', "radius", Required = false, HelpText = "Inner circle radius in circle modes (20-80)")]
     public uint? InnerRadius { get; set; }
     /// <summary>
     /// Active color profile index

--- a/NickvisionCavalier.Shared/Models/CmdOptions.cs
+++ b/NickvisionCavalier.Shared/Models/CmdOptions.cs
@@ -9,7 +9,7 @@ public class CmdOptions {
     /// <summary>
     /// Active drawing mode
     /// </summary>
-    [Option('d', "drawing-mode", Required = false, HelpText = "Drawing mode, one of: wavebox, levelsbox, particlesbox, barsbox, spinebox, splitterbox")]
+    [Option('d', "drawing-mode", Required = false, HelpText = "Drawing mode, one of: wavebox, levelsbox, particlesbox, barsbox, spinebox, splitterbox, wavecircle, levelscircle, particlescircle, barscircle, spinecircle")]
     public DrawingMode? Mode { get; set; }
     /// <summary>
     /// Mirror mode
@@ -76,6 +76,11 @@ public class CmdOptions {
     /// </summary>
     [Option('e', "reverse-order", Required = false, HelpText = "Reverse order of bars (true or false)")]
     public bool? ReverseOrder { get; set; }
+    /// <summary>
+    /// Inner circle radius ratio in circle modes (20-80)
+    /// </summary>
+    [Option('u', "inner-radius", Required = false, HelpText = "Inner circle radius in circle modes (20-80)")]
+    public uint? InnerRadius { get; set; }
     /// <summary>
     /// Active color profile index
     /// </summary>

--- a/NickvisionCavalier.Shared/Models/Configuration.cs
+++ b/NickvisionCavalier.Shared/Models/Configuration.cs
@@ -106,6 +106,10 @@ public class Configuration : IConfiguration
     /// </summary>
     public bool ReverseMirror { get; set; }
     /// <summary>
+    /// Inner circle radius ratio in circle modes (0.2-0.8)
+    /// </summary>
+    public float InnerRadius { get; set; }
+    /// <summary>
     /// List of color profiles
     /// </summary>
     public List<ColorProfile> ColorProfiles { get; set; }
@@ -156,6 +160,7 @@ public class Configuration : IConfiguration
         Mode = DrawingMode.WaveBox;
         Mirror = Mirror.Off;
         ReverseMirror = false;
+        InnerRadius = 0.5f;
         ColorProfiles = new List<ColorProfile> { new ColorProfile() };
         ActiveProfile = 0;
         ImageIndex = -1;

--- a/NickvisionCavalier.Shared/Models/DrawingMode.cs
+++ b/NickvisionCavalier.Shared/Models/DrawingMode.cs
@@ -10,5 +10,10 @@ public enum DrawingMode
     ParticlesBox,
     BarsBox,
     SpineBox,
-    SplitterBox
+    SplitterBox,
+    WaveCircle,
+    LevelsCircle,
+    ParticlesCircle,
+    BarsCircle,
+    SpineCircle
 }

--- a/NickvisionCavalier.Shared/Models/Renderer.cs
+++ b/NickvisionCavalier.Shared/Models/Renderer.cs
@@ -7,6 +7,9 @@ using System.IO;
 
 namespace NickvisionCavalier.Shared.Models;
 
+/// <summary>
+/// An object that renders the picture
+/// </summary>
 public class Renderer
 {
     private delegate void DrawFunc(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint);
@@ -18,8 +21,14 @@ public class Renderer
     private float _oldHeight;
     private float _oldScale;
 
+    /// <summary>
+    /// Renderer's canvas to draw on
+    /// </summary>
     public SKCanvas? Canvas { get; set; }
     
+    /// <summary>
+    /// Construct Renderer
+    /// </summary>
     public Renderer()
     {
         Canvas = null;
@@ -29,6 +38,12 @@ public class Renderer
         _oldScale = 0.0f;
     }
     
+    /// <summary>
+    /// Draw picture
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="width">Picture width</param>
+    /// <param name="height">Picture height</param>
     public void Draw(float[] sample, float width, float height)
     {
         if (Canvas == null)
@@ -144,7 +159,7 @@ public class Renderer
     }
 
     /// <summary>
-    /// Creates gradient shader
+    /// Create gradient shader
     /// </summary>
     /// <param name="colorStrings">List of colors as strings</param>
     /// <param name="width">Canvas width</param>
@@ -183,6 +198,10 @@ public class Renderer
         };
     }
 
+    /// <summary>
+    /// Get direction for mirrored part of picture
+    /// </summary>
+    /// <returns>DrawingDirection</returns>
     private DrawingDirection GetMirrorDirection()
     {
         return Configuration.Current.Direction switch
@@ -194,6 +213,10 @@ public class Renderer
         };
     }
 
+    /// <summary>
+    /// Get X coordinate for mirror top-left corner
+    /// </summary>
+    /// <returns>X coordinate float</returns>
     private float GetMirrorX(float width)
     {
         if (Configuration.Current.Direction == DrawingDirection.LeftRight || Configuration.Current.Direction == DrawingDirection.RightLeft)
@@ -203,6 +226,10 @@ public class Renderer
         return Configuration.Current.AreaMargin;
     }
 
+    /// <summary>
+    /// Get Y coordinate for mirror top-left corner
+    /// </summary>
+    /// <returns>Y coordinate float</returns>
     private float GetMirrorY(float height)
     {
         if (Configuration.Current.Direction == DrawingDirection.TopBottom || Configuration.Current.Direction == DrawingDirection.BottomTop)
@@ -212,6 +239,10 @@ public class Renderer
         return Configuration.Current.AreaMargin;
     }
 
+    /// <summary>
+    /// Get width for mirrored part of picture
+    /// </summary>
+    /// <returns>Width float</returns>
     private float GetMirrorWidth(float width)
     {
         if (Configuration.Current.Direction == DrawingDirection.LeftRight || Configuration.Current.Direction == DrawingDirection.RightLeft)
@@ -221,6 +252,10 @@ public class Renderer
         return width;
     }
 
+    /// <summary>
+    /// Get height for mirrored part of picture
+    /// </summary>
+    /// <returns>Height float</returns>
     private float GetMirrorHeight(float height)
     {
         if (Configuration.Current.Direction == DrawingDirection.TopBottom || Configuration.Current.Direction == DrawingDirection.BottomTop)
@@ -230,6 +265,16 @@ public class Renderer
         return height;
     }
 
+    /// <summary>
+    /// Draw picture, Wave mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawWaveBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / (sample.Length - 1);
@@ -316,6 +361,16 @@ public class Renderer
         Canvas.DrawPath(path, paint);
     }
 
+    /// <summary>
+    /// Draw picture, Levels mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawLevelsBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / sample.Length;
@@ -364,6 +419,16 @@ public class Renderer
         }
     }
 
+    /// <summary>
+    /// Draw picture, Particles mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawParticlesBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / sample.Length;
@@ -409,6 +474,16 @@ public class Renderer
         }
     }
 
+    /// <summary>
+    /// Draw picture, Bars mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawBarsBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / sample.Length;
@@ -456,6 +531,16 @@ public class Renderer
         }
     }
 
+    /// <summary>
+    /// Draw picture, Spine mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawSpineBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / sample.Length;
@@ -563,6 +648,16 @@ public class Renderer
         return paint;
     }
 
+    /// <summary>
+    /// Draw picture, Splitter mode, Box variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
     private void DrawSplitterBox(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var step = (direction < DrawingDirection.LeftRight ? width : height) / sample.Length;
@@ -643,7 +738,17 @@ public class Renderer
         Canvas.DrawPath(path, paint);
     }
 
-    public void DrawWaveCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
+    /// <summary>
+    /// Draw picture, Wave mode, Circle variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
+    private void DrawWaveCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var fullRadius = Math.Min(width, height) / 2;
         var innerRadius = fullRadius * Configuration.Current.InnerRadius;
@@ -654,8 +759,8 @@ public class Renderer
         Canvas.ClipPath(clipPath, SKClipOperation.Difference, true);
         using var path = new SKPath();
         path.MoveTo(
-        x + width / 2 + (innerRadius + radius * sample[0]) * (float)Math.Cos(Math.PI / 2),
-        y + height / 2 + (innerRadius + radius * sample[0]) * (float)Math.Sin(Math.PI / 2));
+            x + width / 2 + (innerRadius + radius * sample[0]) * (float)Math.Cos(Math.PI / 2),
+            y + height / 2 + (innerRadius + radius * sample[0]) * (float)Math.Sin(Math.PI / 2));
         for (var i = 0; i < sample.Length - 1; i++)
         {
             path.CubicTo(
@@ -678,7 +783,17 @@ public class Renderer
         Canvas.Restore();
     }
 
-    public void DrawLevelsCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
+    /// <summary>
+    /// Draw picture, Levels mode, Circle variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
+    private void DrawLevelsCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var fullRadius = Math.Min(width, height) / 2;
         var innerRadius = fullRadius * Configuration.Current.InnerRadius;
@@ -703,7 +818,17 @@ public class Renderer
         }
     }
 
-    public void DrawParticlesCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
+    /// <summary>
+    /// Draw picture, Particles mode, Circle variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
+    private void DrawParticlesCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var fullRadius = Math.Min(width, height) / 2;
         var innerRadius = fullRadius * Configuration.Current.InnerRadius;
@@ -725,7 +850,17 @@ public class Renderer
         }
     }
 
-    public void DrawBarsCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
+    /// <summary>
+    /// Draw picture, Bars mode, Circle variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
+    private void DrawBarsCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var fullRadius = Math.Min(width, height) / 2;
         var innerRadius = fullRadius * Configuration.Current.InnerRadius;
@@ -745,7 +880,17 @@ public class Renderer
         }
     }
 
-    public void DrawSpineCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
+    /// <summary>
+    /// Draw picture, Spine mode, Circle variant
+    /// </summary>
+    /// <param name="sample">CAVA sample</param>
+    /// <param name="direction">DrawingDirection</param>
+    /// <param name="x">Top-left corner X coordinate</param>
+    /// <param name="y">Top-left corner Y coordinate</param>
+    /// <param name="width">Drawing width</param>
+    /// <param name="height">Drawing height</param>
+    /// <param name="paint">Skia paint</param>
+    private void DrawSpineCircle(float[] sample, DrawingDirection direction, float x, float y, float width, float height, SKPaint paint)
     {
         var fullRadius = Math.Min(width, height) / 2;
         var innerRadius = fullRadius * Configuration.Current.InnerRadius;

--- a/NickvisionCavalier.Shared/Models/Renderer.cs
+++ b/NickvisionCavalier.Shared/Models/Renderer.cs
@@ -769,7 +769,7 @@ public class Renderer
             Canvas.RotateDegrees(360 * (i + 0.5f) / sample.Length);
             Canvas.DrawRoundRect(
                 -barWidth * (1 - Configuration.Current.ItemsOffset * 2) / 2 * sample[i] + (Configuration.Current.Filling ? 0 : Configuration.Current.LinesThickness / 2),
-                y + innerRadius - itemSize * sample[i] / 2,
+                innerRadius - itemSize * sample[i] / 2,
                 itemSize * sample[i], itemSize * sample[i],
                 itemSize * sample[i] / 2 * Configuration.Current.ItemsRoundness,
                 itemSize * sample[i] / 2 * Configuration.Current.ItemsRoundness,

--- a/NickvisionCavalier.Shared/Resources/po/cavalier.pot
+++ b/NickvisionCavalier.Shared/Resources/po/cavalier.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr ""
@@ -26,12 +26,12 @@ msgstr ""
 msgid "Add New Profile"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr ""
@@ -56,16 +56,16 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr ""
 
@@ -78,11 +78,11 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -98,15 +98,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr ""
 
@@ -114,12 +114,12 @@ msgstr ""
 msgid "Profile Name"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr ""
@@ -147,248 +147,260 @@ msgstr ""
 msgid "Drawing mode"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
-msgid "Wave"
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
+msgid "Wave"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
-msgid "Offset between items"
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
-msgid "The size of spaces between elements (in percent)."
-msgstr ""
-
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
-msgid "Roundness of items"
+msgid "Drawing area margin"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
-msgid "How much rounded the elements should be (in percent)."
+msgid "Size of gaps around drawing area (in pixels)."
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
-msgid "Filling"
+msgid "Offset between items"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+msgid "The size of spaces between elements (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
+msgid "Roundness of items"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
+msgid "How much rounded the elements should be (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
+msgid "Filling"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
 "Higher value leads to a slower and smoother result."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -397,93 +409,97 @@ msgid "Change Drawing Mode"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
-msgid "Change Mirror Mode"
+msgid "Change radius in Circle modes"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
-msgid "Toggle Reverse Mirror"
+msgid "Change Mirror Mode"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
-msgid "Change Drawing Area Margin"
+msgid "Toggle Reverse Mirror"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
-msgid "Change Drawing Direction"
+msgid "Change Drawing Area Margin"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
-msgid "Change Offset Between Items"
+msgid "Change Drawing Direction"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
-msgid "Change Items Roundness"
+msgid "Change Offset Between Items"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
-msgid "Toggle Filling"
+msgid "Change Items Roundness"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
-msgid "Change Lines Thickness"
+msgid "Toggle Filling"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
-msgid "Toggle Window Borders"
+msgid "Change Lines Thickness"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+msgid "Toggle Window Borders"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr ""

--- a/NickvisionCavalier.Shared/Resources/po/cs.po
+++ b/NickvisionCavalier.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-31 13:53+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Přidat"
@@ -28,12 +28,12 @@ msgstr "Přidat"
 msgid "Add New Profile"
 msgstr "Přidat nový profil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Opravdu chcete odstranit profil „{0}“?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Zrušit"
@@ -58,16 +58,16 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Smazat"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Smazat Profil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Plný"
 
@@ -80,11 +80,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "Obrázky JPEG a PNG"
 
@@ -100,15 +100,15 @@ msgstr "Nový barevný profil bude kopie současně aktivního profilu."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Vypnuto"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Zapnuto"
 
@@ -116,12 +116,12 @@ msgstr "Zapnuto"
 msgid "Profile Name"
 msgstr "Název profilu"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Vybrat obrázek"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Rozdělit kanály"
 
@@ -140,7 +140,7 @@ msgid "Command Help"
 msgstr "Nápověda k příkazům"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Předvolby"
@@ -149,163 +149,175 @@ msgstr "Předvolby"
 msgid "Drawing mode"
 msgstr "Režim vykreslování"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Vlna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Úrovně"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Částečky"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Tyče"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Páteř"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Rozdělovač"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Zrcadlo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Opačné zrcadlení"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Okraje vykreslovací plochy"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Velikost mezer okolo vykreslovací oblasti (v pixelech)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Směr vykreslování"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "Shora dolů"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "Zdola nahoru"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "Zleva doprava"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "Zprava doleva"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Okraje vykreslovací plochy"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Velikost mezer okolo vykreslovací oblasti (v pixelech)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Odsazení mezi položkami"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "Velikost mezer mezi prvky (v procentech)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Zaoblení položek"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Jak moc zaoblené prvky budou (v procentech)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Výplň"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Zda tvary budou vyplněny nebo obtáhnuty."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Tloušťka čar"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Tloušťka čar když vyplňování je vypnuto (v pixelech)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Bezrámečkové okno"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Zda vypnout stín a rám okna."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Ostré rohy"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Zda budou rohy hlavního okna ostré."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Ovládání okna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Zda zobrazovat ovlídíní okna."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Automaticky skrýt záhlaví"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr "Zda skrýt záhlaví hlavního okna pokud není zaměřené."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Snímková frekvence"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Počet snímků za vteřinu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Vlastní"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Vlastní snímková frekvence"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Počet tyčí"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Automatická citlivost"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr "Pokus snížit citlivost když tyče jsou na vrcholu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Citlivost"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -313,31 +325,31 @@ msgstr ""
 "Ruční citlivost. Pokud je povolena automatická citlivost, toto bude pouze "
 "prvotní hodnota."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Kanály"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Monstercat vyhlazování"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Zda zapnout takzvané «Monstercat smoothing»."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Redukce šumu"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -347,55 +359,55 @@ msgstr ""
 "signálu.\n"
 "Vyšší hodnota vede k pomalejšímu a hladšímu výsledku."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Opačné pořadí"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Zda obrátit pořadí tyčí každého kanálu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Barvy"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Přidat profil"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Vzhled aplikace"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Světlý"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Tmavý"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Barvy popředí"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Barvy pozadí"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Obrázek"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Přidat obrázek"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Měřítko"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Žádný obrázek"
 
@@ -404,93 +416,98 @@ msgid "Change Drawing Mode"
 msgstr "Změnit režim vykreslování"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Změnit režim vykreslování"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Změnit režim zrcadlení"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Přepnout opačné zrcadlení"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Změnit odsazení vykreslované oblasti"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Změnit směr vykreslování"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Změnit odsazení mezi položkami"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Změnit zaoblení položek"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Přepnout výplň"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Změnit tloušťku čar"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Přepnout okraje okna"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Přepnout ostré rohy"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Změnit počet sloupců"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Přepnout kanály"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Přepnout opačné pořadí"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Jiné"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Změnit barevný profil"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Změnit obrázek na pozadí"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Změnit velikost obrázku"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplikace"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Přepnout na celou obrazovku"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "O aplikaci Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Ukončit"

--- a/NickvisionCavalier.Shared/Resources/po/de.po
+++ b/NickvisionCavalier.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-17 09:43+0000\n"
 "Last-Translator: Renner03 <Renner03@protonmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Hinzufügen"
@@ -29,12 +29,12 @@ msgstr "Hinzufügen"
 msgid "Add New Profile"
 msgstr "Neues Profil hinzufügen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Soll dieses Profil wirklich entfernt werden?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -59,17 +59,17 @@ msgstr ""
 msgid "Default"
 msgstr "Standard"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy
 msgid "Delete Profile"
 msgstr "Farbprofile"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr ""
 
@@ -83,11 +83,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -103,15 +103,15 @@ msgstr "Neues Farbprofil wird eine Kopie vom aktuellen Profil sein."
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Aus"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 #, fuzzy
 msgid "On"
 msgstr "Öffnen"
@@ -121,12 +121,12 @@ msgstr "Öffnen"
 msgid "Profile Name"
 msgstr "Profil:"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 #, fuzzy
 msgid "Split Channels"
 msgstr "Kanäle"
@@ -147,7 +147,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Einstellungen"
@@ -156,173 +156,185 @@ msgstr "Einstellungen"
 msgid "Drawing mode"
 msgstr "Zeichenmodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Welle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Stufen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Partikel"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Säulen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 #, fuzzy
 msgid "Reverse mirror"
 msgstr "Reihenfolge umkehren"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Rand um die Zeichenfläche"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Größe des Rands um die Zeichenfläche herum (in Pixel)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 #, fuzzy
 msgid "Drawing direction"
 msgstr "Zeichenmodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Rand um die Zeichenfläche"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Größe des Rands um die Zeichenfläche herum (in Pixel)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Abstand zwischen Elementen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 #, fuzzy
 msgid "The size of spaces between elements (in percent)."
 msgstr ""
 "Der Abstand zwischen den Elementen im Säulen-, Partikel- und Stufenmodus (in "
 "Prozent)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Rundung der Elemente"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 #, fuzzy
 msgid "Thickness of lines"
 msgstr "Rundung der Elemente"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 #, fuzzy
 msgid "Whether to disable window shadow and borders."
 msgstr "Buttons der Fensterregelung anzeigen."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Spitze Ecken"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Die Ecken des Hauptfensters zuspitzen."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Fensterregler"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Buttons der Fensterregelung anzeigen."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Kopfleiste ausblenden"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Kopfleiste automatisch ausblenden, wenn das Hauptfenster nicht fokussiert "
 "ist."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 #, fuzzy
 msgid "Number of frames per second."
 msgstr "Anzahl der Säulen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Anzahl der Säulen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Automatische Empfindlichkeit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr "Empfindlichkeit senken, wenn die Säulen den Höchststand erreichen."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Empfindlichkeit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -330,32 +342,32 @@ msgstr ""
 "Manuelle Empfindlichkeit. Wenn Automatische Empfindlichkeit eingeschaltet "
 "ist, wird dieser Wert nur als Ursprungswert eingestellt."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Kanäle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 #, fuzzy
 msgid "Monstercat smoothing"
 msgstr "Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Lärmreduzierung"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 #, fuzzy
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
@@ -366,59 +378,59 @@ msgstr ""
 "möglichst eben zu halten. 1 ist sehr langsam und eben, 0 ist schnell und "
 "unruhig."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Reihenfolge umkehren"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 #, fuzzy
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Option für das Umkehren der Reihenfolge der Säulen hinzugefügt."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Farben"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 #, fuzzy
 msgid "Add Profile"
 msgstr "Neues Profil hinzufügen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Hell"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Dunkel"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 #, fuzzy
 msgid "Foreground Colors"
 msgstr "Vordergrundfarben"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 #, fuzzy
 msgid "Background Colors"
 msgstr "Hintergrundfarben"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -428,99 +440,104 @@ msgstr "Zeichenmodus wechseln"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
 #, fuzzy
-msgid "Change Mirror Mode"
+msgid "Change radius in Circle modes"
 msgstr "Zeichenmodus wechseln"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 #, fuzzy
+msgid "Change Mirror Mode"
+msgstr "Zeichenmodus wechseln"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#, fuzzy
 msgid "Toggle Reverse Mirror"
 msgstr "Reihenfolge umkehren"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Rand um die Zeichenfläche ändern"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 #, fuzzy
 msgid "Change Drawing Direction"
 msgstr "Zeichenmodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Abstand zwischen Elementen ändern"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 #, fuzzy
 msgid "Change Items Roundness"
 msgstr "Rundung der Elemente ändern"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 #, fuzzy
 msgid "Toggle Window Borders"
 msgstr "Fensterregler umschalten"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Spitze Ecken umschalten"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Anzahl der Säulen ändern"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Kanäle umschalten"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Reihenfolge umkehren"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 #, fuzzy
 msgid "Change Color Profile"
 msgstr "Farbprofil wechseln"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Tastenkürzel"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 #, fuzzy
 msgid "About Cavalier"
 msgstr "Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Schließen"

--- a/NickvisionCavalier.Shared/Resources/po/es.po
+++ b/NickvisionCavalier.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-08-05 02:08+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-cavalier/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"cavalier/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Añadir"
@@ -28,12 +28,12 @@ msgstr "Añadir"
 msgid "Add New Profile"
 msgstr "Añadir perfil nuevo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "¿Está seguro de que desea eliminar el perfil \"{0}\"?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Cancelar"
@@ -58,16 +58,16 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Borrar perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Completo"
 
@@ -80,11 +80,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr "Corazones"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "Imágenes JPEG y PNG"
 
@@ -100,15 +100,15 @@ msgstr "El perfil de color nuevo será una copia del perfil activo actual."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Apagado"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Activo"
 
@@ -116,12 +116,12 @@ msgstr "Activo"
 msgid "Profile Name"
 msgstr "Nombre del perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Seleccione una imagen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Dividir canales"
 
@@ -140,7 +140,7 @@ msgid "Command Help"
 msgstr "Ayuda de comandos"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferencias"
@@ -149,195 +149,207 @@ msgstr "Preferencias"
 msgid "Drawing mode"
 msgstr "Modo de dibujado"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Onda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Niveles"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Partículas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Columna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Divisor"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Espejo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Espejo inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Margen del área de dibujado"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Tamaño del espacio alrededor del área de dibujado (en píxeles)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Dirección del dibujo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "De arriba a abajo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "De abajo a arriba"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "De izquierda a derecha"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "De derecha a izquierda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Margen del área de dibujado"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Tamaño del espacio alrededor del área de dibujado (en píxeles)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Espacio entre elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "El tamaño de los espacios entre elementos (en porcentaje)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Redondez de los elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Qué tan redondeados deben ser los elementos (en porcentaje)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Relleno"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Si las formas deben rellenarse o contornearse."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Grosor de las líneas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Grosor de las líneas cuando el relleno está desactivado (en píxeles)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Ventana sin bordes"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Si se desactivan la sombra y los bordes de la ventana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Esquinas planas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Si la ventana principal debe ser plana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Controles de ventana"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Si se muestran los controles de ventana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Ocultar la barra de título automáticamente"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Si se oculta la barra de título cuando la ventana principal no está activa."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Fotogramas por segundo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Número de fotogramas por segundo."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Personalizado"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Velocidad de los fotogramas personalizada"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Numero de barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Sensibilidad automática"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 "Intento para reducir la sensibilidad si las barras llegan a su punto máximo."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Sensibilidad"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
 msgstr "Sensibilidad manual. De ser activado, esto será solo el valor inicial."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Canales"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Estéreo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Suavizado Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Si se activa el llamado \"suavizado Monstercat\"."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Reducción de ruido"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -347,55 +359,55 @@ msgstr ""
 "suavidad de la señal.\n"
 "Un valor más alto conduce a un resultado más lento y suave."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Orden inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Si se desea invertir el orden de las barras para cada canal."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Colores"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Añadir perfil"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Tema de la aplicación"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Claro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Oscuro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Colores del primer plano"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Colores de fondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Añadir imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Escala"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Sin imagen"
 
@@ -404,93 +416,98 @@ msgid "Change Drawing Mode"
 msgstr "Cambiar modo de dibujado"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Cambiar modo de dibujado"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Cambiar modo espejo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Conmutar espejo inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Cambiar margen del área de dibujado"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Cambiar dirección del dibujo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Cambiar espacio entre elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Cambiar la redondez de los elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Conmutar relleno"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Cambiar grosor de las líneas"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Conmutar bordes de ventana"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Conmutar bordes planos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Cambiar número de barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Conmutar canales"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Conmutar orden inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Otros"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Cambiar perfil de color"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Cambiar imagen de fondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Cambiar escala de la imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplicación"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Conmutar pantalla completa"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "Acerca de Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Salir"

--- a/NickvisionCavalier.Shared/Resources/po/es.po
+++ b/NickvisionCavalier.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-08-01 19:08+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Añadir"
@@ -28,12 +28,12 @@ msgstr "Añadir"
 msgid "Add New Profile"
 msgstr "Añadir perfil nuevo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "¿Está seguro de que desea eliminar el perfil \"{0}\"?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Cancelar"
@@ -58,16 +58,16 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Borrar perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Completo"
 
@@ -80,11 +80,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "Imágenes JPEG y PNG"
 
@@ -100,15 +100,15 @@ msgstr "El perfil de color nuevo será una copia del perfil activo actual."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Apagado"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Activo"
 
@@ -116,12 +116,12 @@ msgstr "Activo"
 msgid "Profile Name"
 msgstr "Nombre del perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Seleccione una imagen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Dividir canales"
 
@@ -140,7 +140,7 @@ msgid "Command Help"
 msgstr "Ayuda de comandos"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferencias"
@@ -149,195 +149,207 @@ msgstr "Preferencias"
 msgid "Drawing mode"
 msgstr "Modo de dibujado"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Onda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Niveles"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Partículas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Columna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Divisor"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Espejo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Espejo inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Margen del área de dibujado"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Tamaño del espacio alrededor del área de dibujado (en píxeles)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Dirección del dibujo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "De arriba a abajo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "De abajo a arriba"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "De izquierda a derecha"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "De derecha a izquierda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Margen del área de dibujado"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Tamaño del espacio alrededor del área de dibujado (en píxeles)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Espacio entre elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "El tamaño de los espacios entre elementos (en porcentaje)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Redondez de los elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Qué tan redondeados deben ser los elementos (en porcentaje)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Relleno"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Si las formas deben rellenarse o contornearse."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Grosor de las líneas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Grosor de las líneas cuando el relleno está desactivado (en píxeles)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Ventana sin bordes"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Si se desactivan la sombra y los bordes de la ventana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Esquinas planas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Si la ventana principal debe ser plana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Controles de ventana"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Si se muestran los controles de ventana."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Ocultar la barra de título automáticamente"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Si se oculta la barra de título cuando la ventana principal no está activa."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Fotogramas por segundo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Número de fotogramas por segundo."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Personalizado"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Velocidad de los fotogramas personalizada"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Numero de barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Sensibilidad automática"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 "Intento para reducir la sensibilidad si las barras llegan a su punto máximo."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Sensibilidad"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
 msgstr "Sensibilidad manual. De ser activado, esto será solo el valor inicial."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Canales"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Estéreo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Suavizado Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Si se activa el llamado \"suavizado Monstercat\"."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Reducción de ruido"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -347,55 +359,55 @@ msgstr ""
 "suavidad de la señal.\n"
 "Un valor más alto conduce a un resultado más lento y suave."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Orden inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Si se desea invertir el orden de las barras para cada canal."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Colores"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Añadir perfil"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Tema de la aplicación"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Claro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Oscuro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Colores del primer plano"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Colores de fondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Añadir imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Escala"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Sin imagen"
 
@@ -404,93 +416,98 @@ msgid "Change Drawing Mode"
 msgstr "Cambiar modo de dibujado"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Cambiar modo de dibujado"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Cambiar modo espejo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Conmutar espejo inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Cambiar margen del área de dibujado"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Cambiar dirección del dibujo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Cambiar espacio entre elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Cambiar la redondez de los elementos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Conmutar relleno"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Cambiar grosor de las líneas"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Conmutar bordes de ventana"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Conmutar bordes planos"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Cambiar número de barras"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Conmutar canales"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Conmutar orden inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Otros"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Cambiar perfil de color"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Cambiar imagen de fondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Cambiar escala de la imagen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplicación"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Conmutar pantalla completa"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "Acerca de Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Salir"

--- a/NickvisionCavalier.Shared/Resources/po/fi.po
+++ b/NickvisionCavalier.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-28 13:02+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Lisää"
@@ -28,12 +28,12 @@ msgstr "Lisää"
 msgid "Add New Profile"
 msgstr "Lisää uusi profiili"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Haluatko varmasti poistaa profiilin \"{0}\"?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Peru"
@@ -59,16 +59,16 @@ msgstr "David Lapshin {0}"
 msgid "Default"
 msgstr "Oletus"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Poista"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Poista profiili"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Täysi"
 
@@ -82,11 +82,11 @@ msgstr "Fyodor Sobolev {0}"
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -103,15 +103,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Pois"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Päällä"
 
@@ -119,12 +119,12 @@ msgstr "Päällä"
 msgid "Profile Name"
 msgstr "Profiilin nimi"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Jaa kanavat"
 
@@ -143,7 +143,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Asetukset"
@@ -152,249 +152,261 @@ msgstr "Asetukset"
 msgid "Drawing mode"
 msgstr "Piirtotila"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Aalto"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Tasot"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Partikkelit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Palkit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Peili"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Käänteinen peili"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Piirtoalueen reunus"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Piirtosuunta"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "Ylhäältä alas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "Alhaalta ylös"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "Vasemmalta oikealle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "Oikealta vasemmalle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
-msgid "Offset between items"
-msgstr "Siirtymä kohteiden välillä"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
-msgid "The size of spaces between elements (in percent)."
-msgstr ""
-
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
-msgid "Roundness of items"
-msgstr ""
+msgid "Drawing area margin"
+msgstr "Piirtoalueen reunus"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
-msgid "How much rounded the elements should be (in percent)."
+msgid "Size of gaps around drawing area (in pixels)."
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+msgid "Offset between items"
+msgstr "Siirtymä kohteiden välillä"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+msgid "The size of spaces between elements (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
+msgid "Roundness of items"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
+msgid "How much rounded the elements should be (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Täyttö"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Ovatko muodot täytettyjä vai reunustettuja."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Viivojen paksuus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Reunaton ikkuna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Terävät kulmat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Ikkunasäätimet"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Piilota otsakepalkki automaattisesti"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Kuvanopeus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 #, fuzzy
 msgid "Custom Framerate"
 msgstr "Kuvanopeus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Palkkien määrä"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Kanavat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
 "Higher value leads to a slower and smoother result."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Käänteinen järjestys"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Värit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Lisää profiili"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Sovelluksen teema"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Vaalea"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Tumma"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Edustavärit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Taustavärit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -403,94 +415,99 @@ msgid "Change Drawing Mode"
 msgstr "Vaihda piirtotilaa"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Vaihda piirtotilaa"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Vaihda peilitilaa"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Vaihda piirtoalueen reunusta"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Vaihda piirtosuuntaa"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 #, fuzzy
 msgid "Change Color Profile"
 msgstr "Vaihda peilitilaa"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Sovellus"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Koko näyttö päälle/pois"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Pikanäppäimet"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "Tietoja - Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Lopeta"

--- a/NickvisionCavalier.Shared/Resources/po/fr.po
+++ b/NickvisionCavalier.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-03 09:16+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Ajouter"
@@ -28,12 +28,12 @@ msgstr "Ajouter"
 msgid "Add New Profile"
 msgstr "Ajouter un nouveau profil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Êtes-vous sûr⋅e de vouloir supprimer le profil « {0} » ?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Annuler"
@@ -59,16 +59,16 @@ msgstr "David Lapshin {0}"
 msgid "Default"
 msgstr "Par défaut"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Supprimer le profil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Intégral"
 
@@ -82,11 +82,11 @@ msgstr "Fyodor Sobolev {0}"
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -102,15 +102,15 @@ msgstr "Le nouveau profil de couleur sera une copie du profil actif actuel."
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Désactivé"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Activé"
 
@@ -118,12 +118,12 @@ msgstr "Activé"
 msgid "Profile Name"
 msgstr "Nom du profil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Séparer les canaux"
 
@@ -142,7 +142,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Préférences"
@@ -151,167 +151,179 @@ msgstr "Préférences"
 msgid "Drawing mode"
 msgstr "Mode de dessin"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Ondulations"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Niveaux"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Particules"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Barres"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Colonne vertébrale"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Miroir"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 #, fuzzy
 msgid "Reverse mirror"
 msgstr "Inverser l’ordre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Marge autour de l’aire de dessin"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Espace (en pixels) laissé autour de l’aire dessinée."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Direction du dessin"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "De haut en bas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "De bas en haut"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "De gauche à droite"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "De droite à gauche"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Marge autour de l’aire de dessin"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Espace (en pixels) laissé autour de l’aire dessinée."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Espace entre les éléments"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "Taille des espaces entre les éléments (en pourcentages)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Rondeur des éléments"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Ajuste la rondeur des éléments (en pourcentages)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Remplissage"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Indique si les formes devraient être remplies délimitées."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Épaisseur des lignes"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Épaisseur des lignes quand le remplissage est désactivé (en pixels)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Fenêtre sans bordures"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Indique s’il faut désactiver l’ombre et les bordures de la fenêtre."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Angles saillants"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Indique si les angles de la fenêtre principale doivent être saillants."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Contrôles de la fenêtre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Indique s’il faut afficher les boutons de contrôle de la fenêtre."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Masquer automatiquement la barre supérieure"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Indique s’il faut masquer la barre supérieure lorsque la fenêtre n’est pas "
 "focalisée."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Fréquence"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Nombre d’images par secondes."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 #, fuzzy
 msgid "Custom Framerate"
 msgstr "Fréquence"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Nombre de barres"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Sensibilité automatique"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr "Essayer de diminuer la sensibilité si les barres atteignent un pic."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Sensibilité"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -319,31 +331,31 @@ msgstr ""
 "Sensibilité définie manuellement. Si la sensibilité automatique est activée, "
 "ce sera la valeur initiale."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Canaux"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stéréo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Lissage Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Indique s’il faut activer le « lissage Monstercat »."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Réduction de bruit"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -353,55 +365,55 @@ msgstr ""
 "signal lisse.\n"
 "Plus la valeur est élevée, plus le rendu sera lent et lisse."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Inverser l’ordre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Indique s’il faut inverser l’ordre des barres pour chaque canal."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Couleurs"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Ajouter un profil"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Thème de l’application"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Clair"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Sombre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Couleurs de premier-plan"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Couleurs d’arrière-plan"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -410,95 +422,100 @@ msgid "Change Drawing Mode"
 msgstr "Changer le mode de dessin"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Changer le mode de dessin"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Changer le mode du miroir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 #, fuzzy
 msgid "Toggle Reverse Mirror"
 msgstr "Basculer l’inversion de l’ordre"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Modifier la marge autour de l’aire de dessin"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Changer la direction du dessin"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Modifier l’espace entre les éléments"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Modifier la rondeur des éléments"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Activer/désactiver le remplissage"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Modifier l’épaisseur des lignes"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Afficher/masquer les bordures de la fenêtre"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Activer / désactiver les angles saillants"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Changer le nombre de barres"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Changer le canal"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Basculer l’inversion de l’ordre"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 #, fuzzy
 msgid "Change Color Profile"
 msgstr "Changer le profil de couleurs"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Application"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Basculer en plein écran"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "À propos de Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Quitter"

--- a/NickvisionCavalier.Shared/Resources/po/it.po
+++ b/NickvisionCavalier.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-31 13:53+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Aggiungi"
@@ -28,12 +28,12 @@ msgstr "Aggiungi"
 msgid "Add New Profile"
 msgstr "Aggiungi nuovo profilo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Sei sicuro di voler rimuovere il profilo \"{0}\"?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Cancella"
@@ -58,16 +58,16 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predefinito"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Elimina profilo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Pieno"
 
@@ -80,11 +80,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repo GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "Immagini JPEG e PNG"
 
@@ -100,15 +100,15 @@ msgstr "Il nuovo profilo colore sarà una copia del profilo attivo corrente."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Off"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Acceso"
 
@@ -116,12 +116,12 @@ msgstr "Acceso"
 msgid "Profile Name"
 msgstr "Nome profilo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Seleziona un'immagine"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Dividi canali"
 
@@ -140,7 +140,7 @@ msgid "Command Help"
 msgstr "Comando Aiuto"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferenze"
@@ -149,165 +149,177 @@ msgstr "Preferenze"
 msgid "Drawing mode"
 msgstr "Modalità disegno"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Onda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Livelli"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Particelle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Barre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Colonna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Separatore"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Specchio"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Specchio rovesciato"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Margine dell'area di disegno"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Dimensione degli spazi attorno all'area di disegno (in pixel)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Direzione disegno"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "Dall'alto al basso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "Dal basso verso l'alto"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "Da sinistra a destra"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "Da destra a sinistra"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Margine dell'area di disegno"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Dimensione degli spazi attorno all'area di disegno (in pixel)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Scostamento tra gli elementi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "La dimensione degli spazi tra gli elementi (in percentuale)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Rotondità degli oggetti"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Quanto dovrebbero essere arrotondati gli elementi (in percentuale)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Riempimento"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Se le forme devono essere riempite o delineate."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Spessore delle linee"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Spessore delle linee quando il riempimento è disattivato (in pixel)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Finestra senza bordi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Se disabilitare l'ombreggiatura e i bordi della finestra."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Angoli acuti"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Se gli angoli della finestra principale devono essere nitidi."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Controlli finestra"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Se mostrare i pulsanti di controllo della finestra."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Nascondi automaticamente barra di intestazione"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Se nascondere la barra di intestazione quando la finestra principale non è "
 "focalizzata."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Frequenza dei fotogrammi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Numero di fotogrammi al secondo."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Frequenza fotogrammi personalizzata"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Numero di barre"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Sensibilità automatica"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr "Tenta di ridurre la sensibilità se le barre raggiungono il picco."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Sensibilità"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -315,31 +327,31 @@ msgstr ""
 "Sensibilità manuale. Se la sensibilità automatica è abilitata, sarà solo il "
 "valore iniziale."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Canali"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Levigatura Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Se abilitare il cosiddetto «Levigatura Monstercat»."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Riduzione del rumore"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -349,55 +361,55 @@ msgstr ""
 "segnale uniforme.\n"
 "Un valore più alto porta a un risultato più lento e uniforme."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Ordine inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Se invertire l'ordine delle barre per ciascun canale."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Colori"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Aggiungi profilo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Tema dell'applicazione"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Chiaro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Scuro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Colori in primo piano"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Colori di sfondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Immagine"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Aggiungi immagine"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Scala"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Nessuna immagine"
 
@@ -406,93 +418,98 @@ msgid "Change Drawing Mode"
 msgstr "Cambia modalità di disegno"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Cambia modalità di disegno"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Cambia modalità specchio"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Attiva/disattiva specchio inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Modifica margine area di disegno"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Cambia direzione disegno"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Modifica scostamento tra gli elementi"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Cambia rotondità elementi"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Attiva/disattiva riempimento"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Cambia lo spessore delle linee"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Attiva/disattiva bordi finestra"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Attiva/disattiva angoli acuti"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Cambia numero di barre"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Abilita/disabilita canali"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Attiva/disattiva ordine inverso"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Altro"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Cambia profilo colore"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Cambia immagine di sfondo"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Cambia la scala dell'immagine"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Applicazione"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Attiva schermo intero"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "Informazioni su Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Esci"
@@ -579,8 +596,8 @@ msgstr ""
 #~ "Added option to change roundness of items in \"levels\" and \"particles\" "
 #~ "modes."
 #~ msgstr ""
-#~ "Aggiunta opzione per modificare la rotondità degli elementi in \"livelli"
-#~ "\" e modalità \"particelle\"."
+#~ "Aggiunta opzione per modificare la rotondità degli elementi in "
+#~ "\"livelli\" e modalità \"particelle\"."
 
 #~ msgid "Import/Export Settings"
 #~ msgstr "Impostazioni di importazione/esportazione"
@@ -599,8 +616,8 @@ msgstr ""
 
 #~ msgid "This setting only affects \"levels\" and \"particles\" modes."
 #~ msgstr ""
-#~ "Questa impostazione riguarda solo le modalità \"livelli\" e \"particelle"
-#~ "\"."
+#~ "Questa impostazione riguarda solo le modalità \"livelli\" e "
+#~ "\"particelle\"."
 
 #~ msgid "Number of bars in CAVA config"
 #~ msgstr "Numero di barre nella configurazione CAVA"
@@ -627,8 +644,8 @@ msgstr ""
 #~ "This setting only affects \"levels\" and \"particles\" modes.\n"
 #~ "0 - square, 1 - round"
 #~ msgstr ""
-#~ "Questa impostazione riguarda solo le modalità \"livelli\" e \"particelle"
-#~ "\".\n"
+#~ "Questa impostazione riguarda solo le modalità \"livelli\" e "
+#~ "\"particelle\".\n"
 #~ "0 - quadrato, 1 - rotondo"
 
 #~ msgid "Import"

--- a/NickvisionCavalier.Shared/Resources/po/nl.po
+++ b/NickvisionCavalier.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-31 13:53+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Toevoegen"
@@ -27,12 +27,12 @@ msgstr "Toevoegen"
 msgid "Add New Profile"
 msgstr "Nieuw profiel toevoegen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Weet u zeker dat u dit profiel wilt verwijderen?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Annuleren"
@@ -57,17 +57,17 @@ msgstr ""
 msgid "Default"
 msgstr "Standaard"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy
 msgid "Delete Profile"
 msgstr "Kleurenprofielen"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr ""
 
@@ -81,11 +81,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -101,15 +101,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Uit"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Aan"
 
@@ -118,12 +118,12 @@ msgstr "Aan"
 msgid "Profile Name"
 msgstr "Profiel:"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 #, fuzzy
 msgid "Split Channels"
 msgstr "Kanalen"
@@ -144,7 +144,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Voorkeuren"
@@ -153,174 +153,186 @@ msgstr "Voorkeuren"
 msgid "Drawing mode"
 msgstr "Weergavemodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Golf"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Niveaus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Deeltjes"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Balken"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 #, fuzzy
 msgid "Reverse mirror"
 msgstr "Volgorde omdraaien"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Weergavemodusmarge"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "De grootte van ruimtes om het weergavegebied heen (in pixels)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 #, fuzzy
 msgid "Drawing direction"
 msgstr "Weergavemodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Weergavemodusmarge"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "De grootte van ruimtes om het weergavegebied heen (in pixels)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Verschuiving tussen items"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 #, fuzzy
 msgid "The size of spaces between elements (in percent)."
 msgstr ""
 "De ruimte tussen elementen in niveau-, balk- en deeltjesmodi (in procenten)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Rondheid van items"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 #, fuzzy
 msgid "Thickness of lines"
 msgstr "Rondheid van items"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 #, fuzzy
 msgid "Whether to disable window shadow and borders."
 msgstr "Of de titelbalkknoppen getoond dienen te worden."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Scherpe hoeken"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Of het hoofdvenster scherpe hoeken dient te hebben."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Titelbalkknoppen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Of de titelbalkknoppen getoond dienen te worden."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Kopbalk automatisch verbergen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 "Of de kopbalk automatisch moet worden verborgen als het hoofdvenster niet "
 "gefocust is."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 #, fuzzy
 msgid "Number of frames per second."
 msgstr "Aantal balken"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Aantal balken"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Automatische gevoeligheid"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 "Probeer de gevoeligheid te verlagen zodra het maximale aantal balken bereikt "
 "is."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Gevoeligheidsgraad"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -328,32 +340,32 @@ msgstr ""
 "De handmatige gevoeligheidsgraad. Als de automatische modus is ingeschakeld, "
 "dan wordt dit als startwaarde gebruikt."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Kanalen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 #, fuzzy
 msgid "Monstercat smoothing"
 msgstr "Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Ruisonderdrukking"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 #, fuzzy
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
@@ -363,59 +375,59 @@ msgstr ""
 "Deze factor bepaalt de zwaarte van de filters om het signaal vloeiend door "
 "te laten komen. 1 = erg zwaar, maar vloeiend - 0 = licht, maar met ruis."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Volgorde omdraaien"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 #, fuzzy
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Nieuw: optie om de volgorde van balken aan te passen."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Kleuren"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 #, fuzzy
 msgid "Add Profile"
 msgstr "Profiel toevoegen"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Licht"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Donker"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 #, fuzzy
 msgid "Foreground Colors"
 msgstr "Voorgrondkleuren"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 #, fuzzy
 msgid "Background Colors"
 msgstr "Achtergrondkleuren"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -425,99 +437,104 @@ msgstr "Weergavemodus aanpassen"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
 #, fuzzy
-msgid "Change Mirror Mode"
+msgid "Change radius in Circle modes"
 msgstr "Weergavemodus aanpassen"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 #, fuzzy
+msgid "Change Mirror Mode"
+msgstr "Weergavemodus aanpassen"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#, fuzzy
 msgid "Toggle Reverse Mirror"
 msgstr "Volgorde omdraaien aan/uit"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Weergavemodusmarge aanpassen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 #, fuzzy
 msgid "Change Drawing Direction"
 msgstr "Weergavemodus"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Verschuiving tussen items aanpassen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 #, fuzzy
 msgid "Change Items Roundness"
 msgstr "Rondheid van items aanpassen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 #, fuzzy
 msgid "Toggle Window Borders"
 msgstr "Titelbalkknoppen tonen/verbergen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Scherpe hoeken aan/uit"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Aantal balken aanpassen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Aantal kanalen aanpassen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Volgorde omdraaien aan/uit"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 #, fuzzy
 msgid "Change Color Profile"
 msgstr "Ander kleurenprofiel kiezen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 #, fuzzy
 msgid "About Cavalier"
 msgstr "Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Afsluiten"

--- a/NickvisionCavalier.Shared/Resources/po/pt_BR.po
+++ b/NickvisionCavalier.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-03-27 20:28-0300\n"
 "Last-Translator: Wagner Costa Gottschald <Wagnercostag@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <wagnercostag@gmail.com>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Adicione"
@@ -28,12 +28,12 @@ msgstr "Adicione"
 msgid "Add New Profile"
 msgstr "Adicione um novo perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Têm certeza que deseja remover esse perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Cancelar"
@@ -58,17 +58,17 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, fuzzy
 msgid "Delete Profile"
 msgstr "Remover perfil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr ""
 
@@ -81,11 +81,11 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr ""
 
@@ -101,15 +101,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Desligado"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 #, fuzzy
 msgid "On"
 msgstr "Abrir"
@@ -119,12 +119,12 @@ msgstr "Abrir"
 msgid "Profile Name"
 msgstr "Perfil:"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 #, fuzzy
 msgid "Split Channels"
 msgstr "Canais"
@@ -145,7 +145,7 @@ msgid "Command Help"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferencias"
@@ -154,250 +154,262 @@ msgstr "Preferencias"
 msgid "Drawing mode"
 msgstr "Ondas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Onda"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Níveis"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Partículas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Marge da onda"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 #, fuzzy
 msgid "Drawing direction"
 msgstr "Ondas"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
-msgid "Offset between items"
-msgstr ""
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
-msgid "The size of spaces between elements (in percent)."
-msgstr ""
-
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
-msgid "Roundness of items"
-msgstr ""
+msgid "Drawing area margin"
+msgstr "Marge da onda"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
-msgid "How much rounded the elements should be (in percent)."
+msgid "Size of gaps around drawing area (in pixels)."
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
-msgid "Filling"
+msgid "Offset between items"
 msgstr ""
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+msgid "The size of spaces between elements (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
+msgid "Roundness of items"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
+msgid "How much rounded the elements should be (in percent)."
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
+msgid "Filling"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Controle de janela"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Sensibilidade automática"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Sensibilidade"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Canais"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Mono"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
 "Higher value leads to a slower and smoother result."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Cores"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 #, fuzzy
 msgid "Add Profile"
 msgstr "Adicione um novo perfil"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Claro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Escuro"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr ""
 
@@ -408,98 +420,103 @@ msgstr "Ondas"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
 #, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Ondas"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#, fuzzy
 msgid "Change Mirror Mode"
 msgstr "Mudar Cores do perfil"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 #, fuzzy
 msgid "Change Drawing Area Margin"
 msgstr "Marge da onda"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 #, fuzzy
 msgid "Change Drawing Direction"
 msgstr "Ondas"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 #, fuzzy
 msgid "Toggle Channels"
 msgstr "Canais"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 #, fuzzy
 msgid "Change Color Profile"
 msgstr "Mudar Cores do perfil"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 #, fuzzy
 msgid "About Cavalier"
 msgstr "Cavalier"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Sair"

--- a/NickvisionCavalier.Shared/Resources/po/ru.po
+++ b/NickvisionCavalier.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cavalier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-08-01 19:08+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Добавить"
@@ -29,12 +29,12 @@ msgstr "Добавить"
 msgid "Add New Profile"
 msgstr "Добавить новый профиль"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "Вы уверены, что хотите удалить профиль \"{0}\"?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "Отмена"
@@ -59,16 +59,16 @@ msgstr "Давид Лапшин"
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Удалить профиль"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Полное"
 
@@ -81,11 +81,11 @@ msgstr "Фёдор Соболев"
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "Изображения JPEG и PNG"
 
@@ -101,15 +101,15 @@ msgstr "Новый цветовой профиль будет копией те�
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Выключено"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Включено"
 
@@ -117,12 +117,12 @@ msgstr "Включено"
 msgid "Profile Name"
 msgstr "Имя профиля"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Выбрать изображение"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Разделить каналы"
 
@@ -141,7 +141,7 @@ msgid "Command Help"
 msgstr "Помощь по командам"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Настройки"
@@ -150,164 +150,176 @@ msgstr "Настройки"
 msgid "Drawing mode"
 msgstr "Режим отрисовки"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Волна"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Уровни"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Частицы"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Шкалы"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Хребет"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Разделитель"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Зеркало"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Развернуть зеркало"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Отступ области отрисовки"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Размер отступа вокруг области отрисовки (в пикселях)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Направление отрисовки"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "Сверху вниз"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "Снизу вверх"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "Слева направо"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "Справа налево"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Отступ области отрисовки"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Размер отступа вокруг области отрисовки (в пикселях)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Расстояние между элементами"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "Размер пространства между элементами (в процентах)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Округлость элементов"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Насколько элементы должны быть скруглены (в процентах)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Заполнение"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Должны ли формы быть заполнены или обведены."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Толщина линий"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Толщина линий при выключенном заполнении (в пикселях)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Отключить границы окна"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Следует ли скрыть тени и границы окна."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Острые углы"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Должны ли углы главного окна быть острыми."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Кнопки управления окном"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Должны ли отображаться кнопки управления окном."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Автоскрытие заголовка"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr "Должен ли отображаться заголовок главного окна, когда оно не в фокусе."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Частота кадров"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Число кадров в секунду."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Другое"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Своя частота кадров"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Количество шкал"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Автоматическая чувствительность"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr ""
 "Пытаться снижать чувствительность, если показатели достигают максимума."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Чувствительность"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -315,31 +327,31 @@ msgstr ""
 "Ручная настройка чувствительности. Если автоматическая чувствительность "
 "включена, этот параметр задаёт только начальное значение."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Каналы"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Моно"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Стерео"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Сглаживание Monstercat"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Следуюет ли включить так называемое «сглаживание Monstercat»."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Шумоподавление"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -349,55 +361,55 @@ msgstr ""
 "сигнал гладким.\n"
 "Высокое значение приведёт к более медленному и гладкому результату."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Обратный порядок"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Следует ли изменить порядок шкал для каждого канала."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Цвета"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Добавить профиль"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Тема приложения"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Светлая"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Тёмная"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Цвета переднего плана"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Цвета фона"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Изображение"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Добавить изображение"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Масштаб"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Без изображения"
 
@@ -406,93 +418,98 @@ msgid "Change Drawing Mode"
 msgstr "Изменить режим отрисовки"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Изменить режим отрисовки"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Изменить режим зеркала"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Развернуть зеркало"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Изменить отступ области отрисовки"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Изменить направление отрисовки"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Изменить расстояние между элементами"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Изменить округлость элементов"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Переключить заполнение"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Изменить толщину линий"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Переключить границы окна"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Переключить острые углы"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Изменить количество шкал"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Переключить каналы"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Переключить обратный порядок"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Прочее"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Изменить профиль цветов"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Изменить фоновое изображение"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Изменить масштаб изображения"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Приложение"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Переключить полный экран"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Комбинации клавиш"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "О приложении"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Выход"

--- a/NickvisionCavalier.Shared/Resources/po/tr.po
+++ b/NickvisionCavalier.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 11:19+0300\n"
+"POT-Creation-Date: 2023-08-05 08:16+0300\n"
 "PO-Revision-Date: 2023-07-31 13:53+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:910
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1013
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:44
 msgid "Add"
 msgstr "Ekle"
@@ -28,12 +28,12 @@ msgstr "Ekle"
 msgid "Add New Profile"
 msgstr "Yeni Profil Ekle"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 #, csharp-format
 msgid "Are you sure you want to delete profile \"{0}\"?"
 msgstr "“{0}” profilini silmek istediğinizden emin misiniz?"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 #: ../../../../NickvisionCavalier.GNOME/Controls/AddProfileDialog.cs:41
 msgid "Cancel"
 msgstr "İptal"
@@ -58,16 +58,16 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Öntanımlı"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:787
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:890
 msgid "Delete"
 msgstr "Sil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:786
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:889
 msgid "Delete Profile"
 msgstr "Profil Sil"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Full"
 msgstr "Tam"
 
@@ -80,11 +80,11 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:700
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:803
 msgid "Hearts"
 msgstr ""
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:912
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1015
 msgid "JPEG and PNG images"
 msgstr "JPEG ve PNG resimler"
 
@@ -100,15 +100,15 @@ msgstr "Yeni renk profili, geçerli etkin profilin bir kopyası olacaktır."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "Off"
 msgstr "Kapalı"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:570
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:671
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:662
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:774
 msgid "On"
 msgstr "Açık"
 
@@ -116,12 +116,12 @@ msgstr "Açık"
 msgid "Profile Name"
 msgstr "Profil Adı"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:909
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:1012
 msgid "Select an image"
 msgstr "Resim seç"
 
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:565
-#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:666
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:657
+#: ../../../../NickvisionCavalier.GNOME/Views/PreferencesDialog.cs:769
 msgid "Split Channels"
 msgstr "Kanalları Ayır"
 
@@ -140,7 +140,7 @@ msgid "Command Help"
 msgstr "Komut Yardımı"
 
 #: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:10
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Tercihler"
@@ -149,163 +149,175 @@ msgstr "Tercihler"
 msgid "Drawing mode"
 msgstr "Çizim kipi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:20
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:24
+msgid "Box"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+msgid "Circle"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:36
 msgid "Wave"
 msgstr "Dalga"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:28
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:44
 msgid "Levels"
 msgstr "Düzeyler"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:38
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:54
 msgid "Particles"
 msgstr "Parçacıklar"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:48
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:64
 msgid "Bars"
 msgstr "Çubuklar"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:58
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:74
 msgid "Spine"
 msgstr "Omurga"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:68
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
 msgid "Splitter"
 msgstr "Ayırıcı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
+msgid "Radius"
+msgstr ""
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Mirror"
 msgstr "Aynala"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:84
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:119
 msgid "Reverse mirror"
 msgstr "Ters ayna"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:96
-msgid "Drawing area margin"
-msgstr "Çizim alanı kenar boşluğu"
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:97
-msgid "Size of gaps around drawing area (in pixels)."
-msgstr "Çizim alanı etrafındaki boşlukların boyutu (piksel olarak)."
-
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:114
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Drawing direction"
 msgstr "Çizim yönü"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Top to bottom"
 msgstr "Yukarıdan aşağıya"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Bottom to top"
 msgstr "Aşağıdan yukarıya"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Left to right"
 msgstr "Soldan sağa"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:133
 msgid "Right to left"
 msgstr "Sağdan sola"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:121
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+msgid "Drawing area margin"
+msgstr "Çizim alanı kenar boşluğu"
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+msgid "Size of gaps around drawing area (in pixels)."
+msgstr "Çizim alanı etrafındaki boşlukların boyutu (piksel olarak)."
+
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
 msgid "Offset between items"
 msgstr "Öğeler arasındaki boşluk"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:122
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
 msgid "The size of spaces between elements (in percent)."
 msgstr "Ögeler arasındaki boşluk (yüzde olarak)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:139
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:175
 msgid "Roundness of items"
 msgstr "Ögelerin yuvarlaklığı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:140
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:176
 msgid "How much rounded the elements should be (in percent)."
 msgstr "Ögelerin ne kadar yuvarlak olacağı (yüzde olarak)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:193
 msgid "Filling"
 msgstr "Dolgu"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:158
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:194
 msgid "Whether shapes should be filled or outlined."
 msgstr "Şekillerin dolgusu veya ana hatları çizilmesi durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:168
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:204
 msgid "Thickness of lines"
 msgstr "Çizgi kalınlığı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:169
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:205
 msgid "Thickness of lines when filling is off (in pixels)."
 msgstr "Dolgu kapalıyken çizgilerin kalınlığı (piksel olarak)."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:189
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:225
 msgid "Borderless window"
 msgstr "Kenarlıksız pencere"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:190
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:226
 msgid "Whether to disable window shadow and borders."
 msgstr "Pencere gölgesinin ve kenarlıkların devre dışı bırakılma durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:200
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:236
 msgid "Sharp corners"
 msgstr "Keskin köşeler"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:201
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:237
 msgid "Whether the main window corners should be sharp."
 msgstr "Ana pencere köşelerinin keskin olma durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:211
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:247
 msgid "Window controls"
 msgstr "Pencere denetimleri"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:212
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:248
 msgid "Whether to show window control buttons."
 msgstr "Pencere denetim düğmelerinin gösterilme durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:222
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:258
 msgid "Autohide headerbar"
 msgstr "Başlık çubuğunu kendiliğinden gizle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:223
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:259
 msgid "Whether to hide headerbar when main window is not focused."
 msgstr "Ana pencere odaklanmadığında başlık çubuğunun gizlenme durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:240
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:276
 msgid "Framerate"
 msgstr "Kare hızı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:241
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:277
 msgid "Number of frames per second."
 msgstr "Saniyedeki kare sayısı."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:243
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:279
 msgid "Custom"
 msgstr "Özel"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:249
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:285
 msgid "Custom Framerate"
 msgstr "Özel Kare Hızı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:254
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:290
 msgid "Number of bars"
 msgstr "Çubuk sayısı"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:271
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:307
 msgid "Automatic sensitivity"
 msgstr "Kendiliğinden duyarlılık"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:272
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:308
 msgid "Attempt to decrease sensitivity if the bars peak."
 msgstr "Çubuklar zirve yaparsa hassasiyeti düşürmeye çalış."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:282
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
 msgid "Sensitivity"
 msgstr "Duyarlılık"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:283
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
 msgid ""
 "Manual sensitivity. If automatic sensitivity is enabled, this will only be "
 "the initial value."
@@ -313,31 +325,31 @@ msgstr ""
 "Elle duyarlılık. Kendiliğinden duyarlılık etkinleştirilirse, bu yalnızca "
 "başlangıç değeri olacaktır."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:298
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:334
 msgid "Channels"
 msgstr "Kanallar"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:305
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:341
 msgid "Mono"
 msgstr "Tekli"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:309
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:345
 msgid "Stereo"
 msgstr "Stereo"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:318
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:354
 msgid "Monstercat smoothing"
 msgstr "Monstercat yumuşatma"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:319
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:355
 msgid "Whether to enable the so-called «Monstercat smoothing»."
 msgstr "Sözde «Monstercat yumuşatmanın» etkinleştirilme durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:329
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:365
 msgid "Noise reduction"
 msgstr "Gürültü azaltma"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:330
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:366
 msgid ""
 "This factor adjusts the integral and gravity filters to keep the signal "
 "smooth.\n"
@@ -347,55 +359,55 @@ msgstr ""
 "ayarlar.\n"
 "Daha yüksek değer, daha yavaş ve daha pürüzsüz sonuç sağlar."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:347
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
 msgid "Reverse order"
 msgstr "Ters sırada"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:348
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:384
 msgid "Whether to reverse order of bars for each channel."
 msgstr "Her kanal için çubukların sırasının ters çevrilme durumu."
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:360
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:396
 msgid "Colors"
 msgstr "Renkler"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:383
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:419
 msgid "Add Profile"
 msgstr "Profil Ekle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
 msgid "Application Theme"
 msgstr "Uygulama Teması"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:414
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:450
 msgid "Light"
 msgstr "Açık"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:418
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:454
 msgid "Dark"
 msgstr "Kyu"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:442
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:478
 msgid "Foreground Colors"
 msgstr "Ön Plan Rengi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:464
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:500
 msgid "Background Colors"
 msgstr "Arka Plan Rengi"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:484
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:520
 msgid "Image"
 msgstr "Resim"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:501
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:537
 msgid "Add Image"
 msgstr "Resim Ekle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:512
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:548
 msgid "Scale"
 msgstr "Ölçekle"
 
-#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:561
+#: NickvisionCavalier.GNOME/Blueprints/preferences_dialog.blp:597
 msgid "No Image"
 msgstr "Resim Yok"
 
@@ -404,93 +416,98 @@ msgid "Change Drawing Mode"
 msgstr "Çizim Kipini Değiştir"
 
 #: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:21
+#, fuzzy
+msgid "Change radius in Circle modes"
+msgstr "Çizim Kipini Değiştir"
+
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Change Mirror Mode"
 msgstr "Ayna Kipini Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:26
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
 msgid "Toggle Reverse Mirror"
 msgstr "Ters Aynayı Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:31
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
 msgid "Change Drawing Area Margin"
 msgstr "Çizim Alanı Kenar Boşluğunu Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:36
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Change Drawing Direction"
 msgstr "Çizim Yönünü Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:41
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
 msgid "Change Offset Between Items"
 msgstr "Ögeler Arasındaki Boşluğu Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:46
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
 msgid "Change Items Roundness"
 msgstr "Ögelerin Yuvarlaklığını Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:51
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Toggle Filling"
 msgstr "Dolguyu Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:56
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Change Lines Thickness"
 msgstr "Çizgi Kalınlığını Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
 msgid "Toggle Window Borders"
 msgstr "Pencere Kenarlıklarını Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:66
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Toggle Sharp Corners"
 msgstr "Keskin Köşeleri Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:75
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Change Number of Bars"
 msgstr "Çubuk Sayısını Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:80
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
 msgid "Toggle Channels"
 msgstr "Kanalları Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:85
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Toggle Reverse Order"
 msgstr "Ters Sıralamayı Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:91
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:96
 msgid "Other"
 msgstr "Diğer"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
 msgid "Change Color Profile"
 msgstr "Renk Profilini Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
 msgid "Change Background Image"
 msgstr "Arka Plan Resmini Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:109
 msgid "Change Image Scale"
 msgstr "Resim Ölçeğini Değiştir"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:110
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:115
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Uygulama"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:113
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:118
 msgid "Toggle Fullscreen"
 msgstr "Tam Ekranı Aç/Kapat"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:123
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:128
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:7
 msgid "About Cavalier"
 msgstr "Cavalier Hakkında"
 
-#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:133
+#: NickvisionCavalier.GNOME/Blueprints/shortcuts_dialog.blp:138
 #: NickvisionCavalier.GNOME/Blueprints/window.blp:8
 msgid "Quit"
 msgstr "Çık"


### PR DESCRIPTION
All modes except for Splitter have Circle variant.
Easter egg works with Spine Circle too.
Unfortunately I didn't find a way for Wave Circle to work nicely with gradient when mirrored, so mirror gets disabled for this mode.

Closes #56 