### PR TITLE
restore the environment variable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,5 +107,7 @@ apps:
     common-id: org.nickvision.cavalier
     desktop: usr/share/applications/org.nickvision.cavalier.desktop
     extensions: [ gnome ]
+    environment:
+      CAVALIER_INPUT_METHOD: pulse
     plugs:
       - audio-playback


### PR DESCRIPTION
I guess when the snap starts XDG_RUNTIME_DIR isn't set yet, but I am not sure how is the snap getting pipewire-0