### PR TITLE
linux: Remove duplicated purism tag

### DIFF
--- a/NickvisionCavalier.Shared/Linux/org.nickvision.cavalier.metainfo.xml.in
+++ b/NickvisionCavalier.Shared/Linux/org.nickvision.cavalier.metainfo.xml.in
@@ -65,7 +65,6 @@
     <display_length compare="ge">360</display_length>
   </requires>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>


### PR DESCRIPTION
Fix duplicated Purism tag error removing workstation related tag.

> custom-key-duplicated Purism::form_factor
> A key can only be used once.